### PR TITLE
Simplify `Tool` API and improve schema handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Add the following to your `Package.swift` file:
 > ollama pull llama3.2
 > ```
 
-
 ### Initializing the client
 
 ```swift
@@ -164,20 +163,62 @@ let weatherTool = Tool<WeatherInput, WeatherOutput>(
     and temperature in °C.
     """,
     parameters: [
-        "type": "object",
-        "properties": [
-            "city": [
-                "type": "string",
-                "description": "The city to get weather for"
-            ]
-        ],
-        "required": ["city"]
-    ]
+        "city": [
+            "type": "string",
+            "description": "The city to get weather for"
+        ]
+    ],
+    required: ["city"]
 ) { input async throws -> WeatherOutput in
     // Implement weather lookup logic here
     return WeatherOutput(temperature: 18.5, conditions: "cloudy")
 }
 ```
+
+> [!IMPORTANT]
+> In version 1.3.0 and later, 
+> the `parameters` argument should contain only the properties object, 
+> not the full JSON schema of the tool. 
+> 
+> For backward compatibility, 
+> passing a full schema in the `parameters` argument 
+> (with `"type"`, `"properties"`, and `"required"` fields) 
+> is still supported but deprecated and will emit a warning in debug builds.
+>
+> <details>
+> <summary>Click to see code examples of old vs. new format</summary>
+>
+> ```swift
+> // ✅ New format
+> let weatherTool = Tool<WeatherInput, WeatherOutput>(
+>     name: "get_current_weather",
+>     description: "Get the current weather for a city",
+>     parameters: [
+>         "city": [
+>             "type": "string",
+>             "description": "The city to get weather for"
+>         ]
+>     ],
+>     required: ["city"]
+> ) { /* implementation */ }
+
+> // ❌ Deprecated format (still works but not recommended)
+> let weatherTool = Tool<WeatherInput, WeatherOutput>(
+>     name: "get_current_weather",
+>     description: "Get the current weather for a city",
+>     parameters: [
+>         "type": "object",
+>         "properties": [
+>             "city": [
+>                 "type": "string",
+>                 "description": "The city to get weather for"
+>             ]
+>         ],
+>         "required": ["city"]
+>     ]
+> ) { /* implementation */ }
+> ```
+> </details>
 
 #### Using Tools in Chat
 

--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -337,7 +337,7 @@ extension Client {
         }
 
         if let tools {
-            params["tools"] = .array(tools.map { .object($0.schema) })
+            params["tools"] = .array(try tools.map { try Value($0.schema) })
         }
 
         return try await fetch(.post, "/api/chat", params: params)

--- a/Sources/Ollama/Tool.swift
+++ b/Sources/Ollama/Tool.swift
@@ -1,7 +1,7 @@
 /// Protocol defining the requirements for a tool that can be used with Ollama
 public protocol ToolProtocol: Sendable {
     /// The JSON Schema describing the tool's interface
-    var schema: [String: Value] { get }
+    var schema: any (Codable & Sendable) { get }
 }
 
 /// A type representing a tool that can be used with Ollama.
@@ -45,8 +45,17 @@ public struct Tool<Input: Codable, Output: Codable>: ToolProtocol {
     ///     ]
     /// }
     /// ```
-    public let schema: [String: Value]
+    public var schema: any (Codable & Sendable) { schemaValue }
+    private(set) var schemaValue: Value
 
+    /// The tool's implementation.
+    ///
+    /// This is the function that will be called when the tool is called.
+    ///
+    /// - Parameter input: The input parameters for the tool
+    /// - Returns: The output of the tool operation
+    /// - Throws: Any errors that occur during tool execution
+    /// - SeeAlso: `callAsFunction(_:)`
     private let implementation: @Sendable (Input) async throws -> Output
 
     /// Creates a new tool with the given schema and implementation.
@@ -58,10 +67,10 @@ public struct Tool<Input: Codable, Output: Codable>: ToolProtocol {
         schema: [String: Value],
         implementation: @Sendable @escaping (Input) async throws -> Output
     ) {
-        self.schema = [
+        self.schemaValue = Value.object([
             "type": .string("function"),
             "function": .object(schema),
-        ]
+        ])
         self.implementation = implementation
     }
 
@@ -71,6 +80,8 @@ public struct Tool<Input: Codable, Output: Codable>: ToolProtocol {
     ///   - name: The name of the tool
     ///   - description: A description of what the tool does
     ///   - parameters: A JSON Schema for the tool's parameters
+    ///   - required: The required parameters of the tool.
+    ///               If not provided, all parameters are optional.
     ///   - implementation: The function that implements the tool's behavior
     /// - Returns: A new Tool instance
     /// - Example:
@@ -96,13 +107,18 @@ public struct Tool<Input: Codable, Output: Codable>: ToolProtocol {
         name: String,
         description: String,
         parameters: [String: Value],
+        required: [String] = [],
         implementation: @Sendable @escaping (Input) async throws -> Output
     ) {
         self.init(
             schema: [
                 "name": .string(name),
                 "description": .string(description),
-                "parameters": .object(parameters),
+                "parameters": .object([
+                    "type": .string("object"),
+                    "properties": .object(parameters),
+                    "required": .array(required.map { .string($0) }),
+                ]),
             ],
             implementation: implementation
         )

--- a/Tests/OllamaTests/ClientTests.swift
+++ b/Tests/OllamaTests/ClientTests.swift
@@ -273,15 +273,12 @@ struct ClientTests {
             name: "lookup_color",
             description: "Gets the RGB values (0-1) for common HTML color names",
             parameters: [
-                "type": "object",
-                "properties": [
-                    "colorName": [
-                        "type": "string",
-                        "description": "Name of the HTML color",
-                    ]
-                ],
-                "required": ["colorName"],
-            ]
+                "colorName": [
+                    "type": "string",
+                    "description": "Name of the HTML color",
+                ]
+            ],
+            required: ["colorName"]
         ) { colorName in
             let colors: [String: HexColorInput] = [
                 "papayawhip": .init(red: 1.0, green: 0.937, blue: 0.835),

--- a/Tests/OllamaTests/Fixtures/HexColorTool.swift
+++ b/Tests/OllamaTests/Fixtures/HexColorTool.swift
@@ -20,29 +20,26 @@ let hexColorTool = Tool<HexColorInput, String>(
         Values are floating-point numbers between 0.0 and 1.0.
         """,
     parameters: [
-        "type": "object",
-        "properties": [
-            "red": [
-                "type": "number",
-                "description": "The red component of the color",
-                "minimum": 0.0,
-                "maximum": 1.0,
-            ],
-            "green": [
-                "type": "number",
-                "description": "The green component of the color",
-                "minimum": 0.0,
-                "maximum": 1.0,
-            ],
-            "blue": [
-                "type": "number",
-                "description": "The blue component of the color",
-                "minimum": 0.0,
-                "maximum": 1.0,
-            ],
+        "red": [
+            "type": "number",
+            "description": "The red component of the color",
+            "minimum": 0.0,
+            "maximum": 1.0,
         ],
-        "required": ["red", "green", "blue"],
-    ]
+        "green": [
+            "type": "number",
+            "description": "The green component of the color",
+            "minimum": 0.0,
+            "maximum": 1.0,
+        ],
+        "blue": [
+            "type": "number",
+            "description": "The blue component of the color",
+            "minimum": 0.0,
+            "maximum": 1.0,
+        ],
+    ],
+    required: ["red", "green", "blue"]
 ) { (input) async throws -> String in
     let r = Int(round(input.red * 255))
     let g = Int(round(input.green * 255))

--- a/Tests/OllamaTests/ToolTests.swift
+++ b/Tests/OllamaTests/ToolTests.swift
@@ -98,6 +98,11 @@ struct ToolTests {
 
     @Test
     func testBackwardsCompatibilityWithFullSchema() throws {
+        // Define a simple struct for testing
+        struct TestInput: Codable {
+            let query: String
+        }
+        
         // Create a tool using the old style (full schema in parameters)
         let oldStyleTool = Tool(
             name: "test_tool",
@@ -163,6 +168,11 @@ struct ToolTests {
 
     @Test
     func testBackwardsCompatibilityWithRequiredField() throws {
+        // Define a simple struct for testing
+        struct TestInput: Codable {
+            let query: String
+        }
+
         // Create a tool with a full schema but no explicit required parameter
         let toolWithImplicitRequired = Tool(
             name: "test_tool",
@@ -222,9 +232,4 @@ struct ToolTests {
         #expect(explicitRequired.count == 1)
         #expect(explicitRequired[0].stringValue == "differentField")
     }
-}
-
-// Define a simple struct for testing
-struct TestInput: Codable {
-    let query: String
 }

--- a/Tests/OllamaTests/ToolTests.swift
+++ b/Tests/OllamaTests/ToolTests.swift
@@ -95,4 +95,136 @@ struct ToolTests {
             #expect(result == testCase.expected, "Failed conversion for \(testCase)")
         }
     }
+
+    @Test
+    func testBackwardsCompatibilityWithFullSchema() throws {
+        // Create a tool using the old style (full schema in parameters)
+        let oldStyleTool = Tool(
+            name: "test_tool",
+            description: "A test tool",
+            parameters: [
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("The search query"),
+                    ])
+                ]),
+                "required": .array([.string("query")]),
+            ]
+        ) { (input: TestInput) async throws -> String in
+            return "result"
+        }
+
+        // Create the same tool using the new style
+        let newStyleTool = Tool(
+            name: "test_tool",
+            description: "A test tool",
+            parameters: [
+                "query": .object([
+                    "type": .string("string"),
+                    "description": .string("The search query"),
+                ])
+            ],
+            required: ["query"]
+        ) { (input: TestInput) async throws -> String in
+            return "result"
+        }
+
+        // Verify both tools generate the same schema
+        guard case let .object(oldSchema) = oldStyleTool.schemaValue,
+            case let .object(newSchema) = newStyleTool.schemaValue,
+            let oldFunction = oldSchema["function"]?.objectValue,
+            let newFunction = newSchema["function"]?.objectValue,
+            let oldParameters = oldFunction["parameters"]?.objectValue,
+            let newParameters = newFunction["parameters"]?.objectValue,
+            let oldProperties = oldParameters["properties"]?.objectValue,
+            let newProperties = newParameters["properties"]?.objectValue,
+            let oldRequired = oldParameters["required"]?.arrayValue,
+            let newRequired = newParameters["required"]?.arrayValue
+        else {
+            Issue.record("Invalid schema structure")
+            return
+        }
+
+        // Compare the properties
+        #expect(oldProperties.count == newProperties.count)
+        #expect(
+            oldProperties["query"]?.objectValue?["type"]
+                == newProperties["query"]?.objectValue?["type"])
+        #expect(
+            oldProperties["query"]?.objectValue?["description"]
+                == newProperties["query"]?.objectValue?["description"])
+
+        // Compare the required fields
+        #expect(oldRequired.count == newRequired.count)
+        #expect(oldRequired[0] == newRequired[0])
+    }
+
+    @Test
+    func testBackwardsCompatibilityWithRequiredField() throws {
+        // Create a tool with a full schema but no explicit required parameter
+        let toolWithImplicitRequired = Tool(
+            name: "test_tool",
+            description: "A test tool",
+            parameters: [
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("The search query"),
+                    ])
+                ]),
+                "required": .array([.string("query")]),
+            ]
+        ) { (input: TestInput) async throws -> String in
+            return "result"
+        }
+
+        // Create a tool with a full schema and an explicit required parameter (which should override)
+        let toolWithExplicitRequired = Tool(
+            name: "test_tool",
+            description: "A test tool",
+            parameters: [
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("The search query"),
+                    ])
+                ]),
+                "required": .array([.string("query")]),  // This should be ignored
+            ],
+            required: ["differentField"]  // This should take precedence
+        ) { (input: TestInput) async throws -> String in
+            return "result"
+        }
+
+        // Verify the required fields are correctly handled
+        guard case let .object(implicitSchema) = toolWithImplicitRequired.schemaValue,
+            case let .object(explicitSchema) = toolWithExplicitRequired.schemaValue,
+            let implicitFunction = implicitSchema["function"]?.objectValue,
+            let explicitFunction = explicitSchema["function"]?.objectValue,
+            let implicitParameters = implicitFunction["parameters"]?.objectValue,
+            let explicitParameters = explicitFunction["parameters"]?.objectValue,
+            let implicitRequired = implicitParameters["required"]?.arrayValue,
+            let explicitRequired = explicitParameters["required"]?.arrayValue
+        else {
+            Issue.record("Invalid schema structure")
+            return
+        }
+
+        // For implicit required from schema, we should see "query"
+        #expect(implicitRequired.count == 1)
+        #expect(implicitRequired[0].stringValue == "query")
+
+        // For explicit required parameter, we should see "differentField"
+        #expect(explicitRequired.count == 1)
+        #expect(explicitRequired[0].stringValue == "differentField")
+    }
+}
+
+// Define a simple struct for testing
+struct TestInput: Codable {
+    let query: String
 }

--- a/Tests/OllamaTests/ToolTests.swift
+++ b/Tests/OllamaTests/ToolTests.swift
@@ -7,13 +7,16 @@ import Testing
 struct ToolTests {
     @Test
     func verifyToolSchema() throws {
-        let schema = hexColorTool.schema
+        guard case let .object(schema) = hexColorTool.schemaValue else {
+            Issue.record("Schema is not an object")
+            return
+        }
 
         // Verify basic schema structure
         #expect(schema["type"]?.stringValue == "function")
 
         guard let function = schema["function"]?.objectValue else {
-            #expect(Bool(false), "Missing or invalid function object in schema")
+            Issue.record("Missing or invalid function object in schema")
             return
         }
 
@@ -21,14 +24,14 @@ struct ToolTests {
         #expect(function["description"]?.stringValue != nil)
 
         guard let parameters = function["parameters"]?.objectValue else {
-            #expect(Bool(false), "Missing or invalid parameters in schema")
+            Issue.record("Missing or invalid parameters in schema")
             return
         }
 
         #expect(parameters["type"]?.stringValue == "object")
 
         guard let properties = parameters["properties"]?.objectValue else {
-            #expect(Bool(false), "Missing or invalid properties in parameters")
+            Issue.record("Missing or invalid properties in parameters")
             return
         }
         #expect(properties.count == 3, "Expected 3 parameters, got \(properties.count)")
@@ -36,7 +39,7 @@ struct ToolTests {
         // Check required parameter definitions and constraints
         for (key, value) in properties {
             guard let paramObj = value.objectValue else {
-                #expect(Bool(false), "Missing parameter object for \(key)")
+                Issue.record("Missing parameter object for \(key)")
                 continue
             }
 


### PR DESCRIPTION
Related to #12 

- Change `ToolProtocol.schema` to accept `any Codable & Sendable` type
- Update `Tool` implementation to handle schema conversion internally
- Simplify parameter definition with separate `required` parameter